### PR TITLE
Add environment variable for custom screenshot directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,37 @@ computer-control-mcp # instead of uvx computer-control-mcp, so you can use the l
 - Press keyboard keys
 - Drag and drop operations
 
+## Configuration
+
+### Custom Screenshot Directory
+
+By default, screenshots are saved to the OS downloads directory. You can customize this by setting the `COMPUTER_CONTROL_MCP_SCREENSHOT_DIR` environment variable:
+
+```json
+{
+  "mcpServers": {
+    "computer-control-mcp": {
+      "command": "uvx",
+      "args": ["computer-control-mcp@latest"],
+      "env": {
+        "COMPUTER_CONTROL_MCP_SCREENSHOT_DIR": "C:\\Users\\YourName\\Pictures\\Screenshots"
+      }
+    }
+  }
+}
+```
+
+Or set it system-wide:
+```bash
+# Windows (PowerShell)
+$env:COMPUTER_CONTROL_MCP_SCREENSHOT_DIR = "C:\Users\YourName\Pictures\Screenshots"
+
+# macOS/Linux
+export COMPUTER_CONTROL_MCP_SCREENSHOT_DIR="/home/yourname/Pictures/Screenshots"
+```
+
+If the specified directory doesn't exist, the server will fall back to the default downloads directory.
+
 ## Available Tools
 
 ### Mouse Control

--- a/src/computer_control_mcp/core.py
+++ b/src/computer_control_mcp/core.py
@@ -64,7 +64,21 @@ def log(message: str) -> None:
 
 
 def get_downloads_dir() -> Path:
-    """Get the OS downloads directory."""
+    """Get the directory for saving screenshots.
+
+    Checks for COMPUTER_CONTROL_MCP_SCREENSHOT_DIR environment variable first,
+    then falls back to the OS downloads directory.
+    """
+    # Check for custom directory from environment variable
+    custom_dir = os.getenv("COMPUTER_CONTROL_MCP_SCREENSHOT_DIR")
+    if custom_dir:
+        custom_path = Path(custom_dir)
+        if custom_path.exists() and custom_path.is_dir():
+            return custom_path
+        else:
+            log(f"Warning: COMPUTER_CONTROL_MCP_SCREENSHOT_DIR path '{custom_dir}' does not exist or is not a directory. Falling back to default.")
+
+    # Default: OS downloads directory
     if os.name == "nt":  # Windows
         import winreg
 


### PR DESCRIPTION
## Summary
- Add `COMPUTER_CONTROL_MCP_SCREENSHOT_DIR` environment variable to customize where screenshots are saved
- Falls back to default OS Downloads directory if not set or path doesn't exist
- Document the configuration option in README

## Motivation
Users may want screenshots saved to a specific folder (e.g., OneDrive Pictures/Screenshots, a project folder, etc.) rather than the default Downloads directory. This is especially useful for:
- Keeping screenshots organized in a dedicated location
- Cloud sync folders like OneDrive/Dropbox
- Project-specific screenshot directories

## Usage
```json
{
  "mcpServers": {
    "computer-control-mcp": {
      "command": "uvx",
      "args": ["computer-control-mcp@latest"],
      "env": {
        "COMPUTER_CONTROL_MCP_SCREENSHOT_DIR": "C:\Users\YourName\Pictures\Screenshots"
      }
    }
  }
}
```

## Test plan
- [x] Verify screenshots save to custom directory when env var is set
- [x] Verify fallback to Downloads when env var is not set
- [x] Verify fallback to Downloads when env var points to non-existent path